### PR TITLE
fix: revert bad Vault migration

### DIFF
--- a/.github/workflows/stale-actions.yml
+++ b/.github/workflows/stale-actions.yml
@@ -7,17 +7,9 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: hashicorp/vault-action@v2
-      with:
-        method: jwt
-        path: jwt-github-actions
-        role: github-issuu-fluentd-kubernetes-daemonset
-        url: https://vault.bendingspoons.com
-        secrets: |
-            static2/data/github/issuu/shared/ci/manual GITHUB_TOKEN
     - uses: actions/stale@v4
       with:
-        repo-token: ${{ env.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 90
         days-before-close: 30
         operations-per-run: 60


### PR DESCRIPTION
${{ secrets.GITHUB_TOKEN }} is not a stored secret but one automatically injected by Github